### PR TITLE
feat: update path for status entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lib/
 
 # User-specific stuff
 **/.idea/
+.vscode/
 
 # CMake
 cmake-build-*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3342,11 +3342,30 @@
       }
     },
     "credential-status": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/credential-status/-/credential-status-1.1.1.tgz",
-      "integrity": "sha512-yxN7snEuiufbtaNCH8JBgbzC2D+dA9yv66ZUSCS7Ghua4ngxybV70SqOkEhiQbPYsNEC19ZNRc3PywJJ6o+HBA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/credential-status/-/credential-status-1.2.1.tgz",
+      "integrity": "sha512-KtbN0BUiYUi9Cjisxb8cO8hOLbE/rEf8Pl5RLoX3U/ocNs71jA04UXmQflW7friLu9Gfw77NuyoEOJHsTZOdSw==",
       "requires": {
-        "did-jwt": "^3.0.0"
+        "did-jwt": "^4.3.2",
+        "did-resolver": "^1.1.0"
+      },
+      "dependencies": {
+        "did-jwt": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.3.2.tgz",
+          "integrity": "sha512-emkWdlt24qfhFVkPvAWIS5o5Wdyz3OyN3OQnkgW3iOow4PvtM3uO0rg1L9P9yKwl+pwg005AfM3WInjFbVjZmQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@stablelib/utf8": "^0.10.1",
+            "buffer": "^5.2.1",
+            "did-resolver": "^1.0.0",
+            "elliptic": "^6.4.0",
+            "js-sha256": "^0.9.0",
+            "js-sha3": "^0.8.0",
+            "tweetnacl": "^1.0.1",
+            "uport-base64url": "3.0.2-alpha.0"
+          }
+        }
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "dependencies": {
     "buffer": "^5.6.0",
-    "credential-status": "^1.1.1",
+    "credential-status": "^1.2.1",
     "did-jwt": "^3.0.0",
     "did-resolver": "^1.1.0",
     "ethjs-contract": "^0.2.3",

--- a/src/EthrCredentialRevoker.ts
+++ b/src/EthrCredentialRevoker.ts
@@ -26,7 +26,7 @@ export class EthrCredentialRevoker {
 
   async revoke(token: string, revokerAddress: string, ethSign?: (rawTx: any, cb: any) => any): Promise<string> {
     const decoded = decodeJWT(token) as JWTDecodedExtended
-    const statusEntry = decoded.payload.status
+    const statusEntry = decoded.payload.credentialStatus
 
     if (!statusEntry) {
       throw new Error('credential_not_revokable; no status field embedded')

--- a/src/EthrStatusRegistry.ts
+++ b/src/EthrStatusRegistry.ts
@@ -51,8 +51,13 @@ export class EthrStatusRegistry implements StatusResolver {
   async checkStatus(credential: string, didDoc: DIDDocument): Promise<null | CredentialStatus> {
     const decodedJWT = decodeJWT(credential).payload as JWTDecodedExtended
 
-    if (decodedJWT.status?.type === methodName) {
-      const [registryAddress, networkId] = this.parseRegistryId(decodedJWT?.status?.id)
+    const statusEntry = decodedJWT.credentialStatus
+    if (!statusEntry) {
+      return Promise.resolve({ status: 'NonRevocable' })
+    }
+
+    if (statusEntry.type === methodName) {
+      const [registryAddress, networkId] = this.parseRegistryId(statusEntry.id)
 
       if (!this.networks[networkId]) {
         return Promise.reject(`networkId (${networkId}) for status check not configured`)

--- a/src/__tests__/basicTests.ts
+++ b/src/__tests__/basicTests.ts
@@ -100,7 +100,10 @@ describe('EthrStatusRegistry', () => {
     })
 
     it(`should reject unknown status method`, async () => {
-      const token = await createJWT({ status: { type: 'unknown', id: 'something something' } }, { issuer, signer })
+      const token = await createJWT(
+        { credentialStatus: { type: 'unknown', id: 'something something' } },
+        { issuer, signer }
+      )
       const statusChecker = new EthrStatusRegistry({ infuraProjectId: 'none' })
       await expect(statusChecker.checkStatus(token, referenceDoc)).rejects.toMatch(
         'unsupported credential status method'
@@ -108,7 +111,7 @@ describe('EthrStatusRegistry', () => {
     })
 
     it(`should reject unknown networkIDs`, async () => {
-      const token = await createJWT({ status: statusEntry }, { issuer, signer })
+      const token = await createJWT({ credentialStatus: statusEntry }, { issuer, signer })
       const statusChecker = new EthrStatusRegistry({
         networks: [{ name: 'some net', rpcUrl: 'example.com' }]
       })
@@ -118,7 +121,7 @@ describe('EthrStatusRegistry', () => {
     })
 
     it(`should throw an error when the RPC endpoint is mis-configured`, async () => {
-      const token = await createJWT({ status: statusEntry }, { issuer, signer })
+      const token = await createJWT({ credentialStatus: statusEntry }, { issuer, signer })
       const statusChecker = new EthrStatusRegistry({
         networks: [{ name: 'ganache', rpcUrl: '0.0.0.0' }]
       })
@@ -128,8 +131,14 @@ describe('EthrStatusRegistry', () => {
   })
 
   describe('happy path', () => {
+    it(`should ignore non-revocable credentials`, async () => {
+      const token = await createJWT({}, { issuer, signer })
+      const statusChecker = new EthrStatusRegistry({ infuraProjectId: 'none' })
+      await expect(statusChecker.checkStatus(token, referenceDoc)).resolves.toMatchObject({ status: 'NonRevocable' })
+    })
+
     it(`should return valid credential status`, async () => {
-      const token = await createJWT({ status: statusEntry }, { issuer, signer })
+      const token = await createJWT({ credentialStatus: statusEntry }, { issuer, signer })
       const statusChecker = new EthrStatusRegistry({
         networks: [{ name: 'ganache', provider: provider }]
       })
@@ -139,24 +148,24 @@ describe('EthrStatusRegistry', () => {
     })
 
     it(`should return revoked status for real credential`, async () => {
-      const token =
-        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzMwNDczNTEsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHgxZmNmOGZmNzhhYzUxMTdkOWM5OWI4MzBjNzRiNjY2OGQ2YWMzMjI5In0.MHabafA0UxJuQJ0Z-7Egb57WRlgj4_zf96B0LUhRyXgVDU5RABIczTTTXWjcuKVzhJc_-FuhRI8uQYmQQNxKzgA'
+      const referenceToken =
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE1ODgxNzE4MDAsInN1YiI6ImRpZDp3ZWI6dXBvcnQubWUiLCJub25jZSI6IjM4NzE4Njc0NTMiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiQXdlc29tZW5lc3NDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Iml0IjoicmVhbGx5IHdoaXBzIHRoZSBsbGFtbWEncyBhc3MhIn19LCJjcmVkZW50aWFsU3RhdHVzIjp7InR5cGUiOiJFdGhyU3RhdHVzUmVnaXN0cnkyMDE5IiwiaWQiOiJyaW5rZWJ5OjB4OTdmZDI3ODkyY2RjRDAzNWRBZTFmZTcxMjM1YzYzNjA0NEI1OTM0OCJ9LCJpc3MiOiJkaWQ6ZXRocjoweDU0ZDU5ZTNmZmQ3NjkxN2Y2MmRiNzAyYWMzNTRiMTdmMzg0Mjk1NWUifQ.kpUbDVrs3ouIs0vb5IqL4_FAErANCZnFE-lTMlC9Hzpwa4u3_8BaJg4y1KIHq_ROr2oEam9UAujd5A4FbbzFoA'
 
       // proj ID only usable for this test
       const statusChecker = new EthrStatusRegistry({ infuraProjectId: 'ec9c99d75b834bac8dd4bfacad8cfdf7' })
 
       const referenceDoc = {
-        id: 'did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229',
+        id: 'did:ethr:0x54d59e3ffd76917f62db702ac354b17f3842955e',
         publicKey: [
           {
-            id: 'did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229#owner',
+            id: 'did:ethr:0x54d59e3ffd76917f62db702ac354b17f3842955e#owner',
             type: 'Secp256k1VerificationKey2018',
-            ethereumAddress: '0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229'
+            ethereumAddress: '0x54d59e3ffd76917f62db702ac354b17f3842955e'
           }
         ]
       } as DIDDocument
 
-      await expect(statusChecker.checkStatus(token, referenceDoc)).resolves.toMatchObject({
+      await expect(statusChecker.checkStatus(referenceToken, referenceDoc)).resolves.toMatchObject({
         revoked: true
       })
     })

--- a/src/__tests__/integration.ts
+++ b/src/__tests__/integration.ts
@@ -4,40 +4,31 @@ import { EthrStatusRegistry } from '../index'
 import { Status } from 'credential-status'
 import { DIDDocument } from 'did-resolver'
 
-const referenceDoc = {
-  '@context': 'https://w3id.org/did/v1',
-  id: 'did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229',
-  authentication: [
-    {
-      type: 'Secp256k1SignatureAuthentication2018',
-      publicKey: 'did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229#owner'
-    }
-  ],
-  publicKey: [
-    {
-      id: 'did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229#owner',
-      type: 'Secp256k1VerificationKey2018',
-      ethereumAddress: '0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229',
-      owner: 'did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229'
-    }
-  ]
-} as DIDDocument
-
-//only usable for this test
-const rinkebyRPC = 'https://rinkeby.infura.io/v3/ec9c99d75b834bac8dd4bfacad8cfdf7'
-
 it(`should return revoked credential status when invoked through wrapper lib`, async () => {
-  const token =
-    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzMwNDczNTEsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHgxZmNmOGZmNzhhYzUxMTdkOWM5OWI4MzBjNzRiNjY2OGQ2YWMzMjI5In0.MHabafA0UxJuQJ0Z-7Egb57WRlgj4_zf96B0LUhRyXgVDU5RABIczTTTXWjcuKVzhJc_-FuhRI8uQYmQQNxKzgA'
+  const referenceToken =
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE1ODgxNzE4MDAsInN1YiI6ImRpZDp3ZWI6dXBvcnQubWUiLCJub25jZSI6IjM4NzE4Njc0NTMiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiQXdlc29tZW5lc3NDcmVkZW50aWFsIl0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Iml0IjoicmVhbGx5IHdoaXBzIHRoZSBsbGFtbWEncyBhc3MhIn19LCJjcmVkZW50aWFsU3RhdHVzIjp7InR5cGUiOiJFdGhyU3RhdHVzUmVnaXN0cnkyMDE5IiwiaWQiOiJyaW5rZWJ5OjB4OTdmZDI3ODkyY2RjRDAzNWRBZTFmZTcxMjM1YzYzNjA0NEI1OTM0OCJ9LCJpc3MiOiJkaWQ6ZXRocjoweDU0ZDU5ZTNmZmQ3NjkxN2Y2MmRiNzAyYWMzNTRiMTdmMzg0Mjk1NWUifQ.kpUbDVrs3ouIs0vb5IqL4_FAErANCZnFE-lTMlC9Hzpwa4u3_8BaJg4y1KIHq_ROr2oEam9UAujd5A4FbbzFoA'
+
+  const referenceDoc = {
+    id: 'did:ethr:0x54d59e3ffd76917f62db702ac354b17f3842955e',
+    publicKey: [
+      {
+        id: 'did:ethr:0x54d59e3ffd76917f62db702ac354b17f3842955e#owner',
+        type: 'Secp256k1VerificationKey2018',
+        ethereumAddress: '0x54d59e3ffd76917f62db702ac354b17f3842955e'
+      }
+    ]
+  } as DIDDocument
+
   const ethrStatus = new EthrStatusRegistry({
-    networks: [{ name: 'rinkeby', rpcUrl: rinkebyRPC }]
+    // rpc only usable for this test
+    networks: [{ name: 'rinkeby', rpcUrl: 'https://rinkeby.infura.io/v3/ec9c99d75b834bac8dd4bfacad8cfdf7' }]
   })
 
   const statusChecker = new Status({
     ...ethrStatus.asStatusMethod
   })
 
-  await expect(statusChecker.checkStatus(token, referenceDoc)).resolves.toMatchObject({
+  await expect(statusChecker.checkStatus(referenceToken, referenceDoc)).resolves.toMatchObject({
     revoked: true
   })
 })


### PR DESCRIPTION
Replaces `status` with `credentialStatus` when judging a credential or presentation.
This brings this library closer to W3C examples

fixes #18