### PR TITLE
feat: override transaction inputs

### DIFF
--- a/src/ExternalSignerProvider.ts
+++ b/src/ExternalSignerProvider.ts
@@ -11,35 +11,43 @@ export class ExternalSignerProvider extends ethers.Signer {
     ethers.utils.defineReadOnly(this, 'provider', provider)
   }
 
-  sign(transaction: ethers.providers.TransactionRequest): Promise<string> {
-    return ethers.utils.resolveProperties(transaction).then((tx) => {
-      return new Promise((resolve, reject) => {
-        this.ethSign(tx, (err, signedTx) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(signedTx)
-          }
-        })
-      })
-    })
+  async sign(transaction: ethers.providers.TransactionRequest): Promise<string> {
+    const tx = await ethers.utils.resolveProperties(transaction)
+    const signed = await this.signRaw(tx)
+    return signed
   }
 
-  getAddress(): Promise<string> {
-    throw new Error('Method not implemented.')
+  async getAddress(): Promise<string> {
+    const signedTx = await this.signRaw({})
+    const decoded = ethers.utils.parseTransaction(signedTx)
+    return decoded.from
   }
 
   signMessage(message: ethers.utils.Arrayish): Promise<string> {
-    throw new Error('Method not implemented.')
+    return Promise.reject(new Error('Method not implemented.'))
   }
 
-  sendTransaction(transaction: ethers.providers.TransactionRequest): Promise<ethers.providers.TransactionResponse> {
+  async sendTransaction(
+    transaction: ethers.providers.TransactionRequest
+  ): Promise<ethers.providers.TransactionResponse> {
     if (!this.provider) {
       throw new Error('missing provider')
     }
 
     return this.sign(transaction).then((signedTransaction) => {
       return this.provider.sendTransaction(signedTransaction)
+    })
+  }
+
+  private signRaw = (rawTx: any): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      this.ethSign(rawTx, (err: any, signedTx: string) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(signedTx)
+        }
+      })
     })
   }
 }

--- a/src/ExternalSignerProvider.ts
+++ b/src/ExternalSignerProvider.ts
@@ -34,6 +34,10 @@ export class ExternalSignerProvider extends ethers.Signer {
       throw new Error('missing provider')
     }
 
+    if (transaction.nonce == null) {
+      transaction.nonce = await this.provider.getTransactionCount(this.getAddress(), 'pending')
+    }
+
     return this.sign(transaction).then((signedTransaction) => {
       return this.provider.sendTransaction(signedTransaction)
     })


### PR DESCRIPTION
allow user to override some transaction params (gas & nonce) when sending the revocation transaction.

Also, this PR adds some more functionality to the externalized signer: autocompute address and nonce